### PR TITLE
Update to odML version 1.4 & add conversion from nix to odml

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,9 @@
-# odML to NIX metadata conversion tool
+# odML - NIX metadata conversion tool
 
-This tool reads in odML files and writes the metadata structure to newly created NIX files.
+This tool reads in odML / NIX files and writes the metadata structure to newly created NIX / odML files.
 When run as a script from the command line, it prints information regarding the number of Sections and Properties that were read, written, or skipped for various reasons.
 
-For compatibility with the NIX metadata format, which differs slightly from the odML format, the following modifications occur:
-
+For compatibility with the NIX metadata format, which differs slightly from the odML format, the following modifications occur when converting from odML to NIX:
 - If a Section has a `reference` create a property called `reference`
 - If a Property has a `reference` put the reference in the Property's
     values

--- a/convert.py
+++ b/convert.py
@@ -93,6 +93,7 @@ def odml_to_nix_recurse(odmlseclist, nixparentsec):
 
         odml_to_nix_recurse(odmlsec.sections, nixsec)
 
+
 def write_odml_doc(odmldoc, nixfile):
     nixsec = nixfile.create_section('odML document', 'odML document', oid=odmldoc.id)
     info["sections written"] += 1
@@ -121,6 +122,7 @@ def odmlwrite(nix_file, filename):
     nix_to_odml_recurse(nix_section.sections, odml_doc)
     odml.fileio.save(odml_doc, filename)
 
+
 def get_odml_doc(nix_file):
     # identify odml document section in nix file
     try:
@@ -144,8 +146,8 @@ def nix_to_odml_recurse(nix_section_list, odml_section):
         # extract and convert section attributes from nix
         # TODO: add 'include' here as soon as available in nix
         attributes = ['name', 'type', 'definition', 'reference', 'repository', 'link', 'id']
-        nix_attributes = {attr: getattr(nix_sec, attr) for attr in attributes
-                          if hasattr(nix_sec, attr)}
+        nix_attributes = {attr: getattr(nix_sec, attr) for attr in attributes if
+                          hasattr(nix_sec, attr)}
         nix_attributes['parent'] = odml_section
         if 'id' in nix_attributes:
             nix_attributes['oid'] = nix_attributes.pop('id')
@@ -156,11 +158,10 @@ def nix_to_odml_recurse(nix_section_list, odml_section):
             info["properties read"] += 1
 
             # extract and convert property attributes from nix
-            prop_attributes = ['name', 'values', 'unit', 'uncertainty', 'reference',
-                               'definition', 'dependency', 'dependency_value', 'odml_type',
-                               'value_origin', 'id']
-            nix_prop_attributes = {attr: getattr(nixprop, attr) for attr in prop_attributes
-                                   if hasattr(nixprop, attr)}
+            prop_attributes = ['name', 'values', 'unit', 'uncertainty', 'reference', 'definition',
+                               'dependency', 'dependency_value', 'odml_type', 'value_origin', 'id']
+            nix_prop_attributes = {attr: getattr(nixprop, attr) for attr in prop_attributes if
+                                   hasattr(nixprop, attr)}
 
             if 'id' in nix_prop_attributes:
                 nix_prop_attributes['oid'] = nix_prop_attributes.pop('id')

--- a/test_convert.py
+++ b/test_convert.py
@@ -1,0 +1,50 @@
+import os
+import unittest
+import odml
+import odml.fileio
+import datetime
+import convert
+import nixio as nix
+
+document_attributes = ['author', 'version', 'date', 'repository']
+section_attributes = ['name', 'oid', 'definition', 'type', 'reference', 'repository',
+                      # 'link', 'include'
+                      ]
+property_attributes= ['name', 'oid', 'definition', 'value', 'unit',
+                      'reference', 'dependency', 'dependency_value', 'dtype', 'value_origin',
+                      # the type conversion of the uncertainty is not solved yet.
+                      #'uncertainty',
+                      ]
+
+
+class TestBlock(unittest.TestCase):
+    def setUp(self):
+        self.odml_doc = odml.Document(author='me', date=datetime.date.today(), version='0.0.1',
+                                      repository='unknown')
+        odml.Section(name='first section', definition='arbitrary definiton',
+                     type='testsection', parent=self.odml_doc, reference='reference 1',
+                     repository='also unknown', link='???', include=False)
+
+        odml.Property(name='first property', value=[1, 2, 3], parent=self.odml_doc.sections[0],
+                      unit='Volt', uncertainty=3, reference='still unknown',
+                      definition='first property recorded', dependency='unknown',
+                      dependency_value='also unknown', dtype='int', value_origin='ref 2')
+
+    def test_double_conversion(self):
+        convert.nixwrite(self.odml_doc, 'tmp.nix')
+        nix_file = nix.File('tmp.nix')
+        convert.odmlwrite(nix_file, 'tmp.odml')
+        odml_doc = odml.fileio.load('tmp.odml')
+
+        for attr in document_attributes:
+            self.assertEqual(getattr(self.odml_doc, attr), getattr(odml_doc, attr))
+
+        for sec in self.odml_doc.sections:
+            sec2 = odml_doc.sections[sec.name]
+            for attr in section_attributes:
+                self.assertEqual(getattr(sec, attr), getattr(sec2, attr))
+
+            for prop in sec.properties:
+                prop2 = sec2.properties[prop.name]
+                for attr in property_attributes:
+                    self.assertEqual(getattr(prop, attr), getattr(prop2, attr))

--- a/test_convert.py
+++ b/test_convert.py
@@ -10,20 +10,20 @@ document_attributes = ['author', 'version', 'date', 'repository']
 section_attributes = ['name', 'oid', 'definition', 'type', 'reference', 'repository',
                       # 'link', 'include'
                       ]
-property_attributes= ['name', 'oid', 'definition', 'value', 'unit',
-                      'reference', 'dependency', 'dependency_value', 'dtype', 'value_origin',
-                      # the type conversion of the uncertainty is not solved yet.
-                      #'uncertainty',
-                      ]
+property_attributes = ['name', 'oid', 'definition', 'value', 'unit', 'reference', 'dependency',
+                       'dependency_value', 'dtype', 'value_origin',
+                       # the type conversion of the uncertainty is not solved yet.
+                       # 'uncertainty',
+                       ]
 
 
 class TestBlock(unittest.TestCase):
     def setUp(self):
         self.odml_doc = odml.Document(author='me', date=datetime.date.today(), version='0.0.1',
                                       repository='unknown')
-        odml.Section(name='first section', definition='arbitrary definiton',
-                     type='testsection', parent=self.odml_doc, reference='reference 1',
-                     repository='also unknown', link='???', include=False)
+        odml.Section(name='first section', definition='arbitrary definiton', type='testsection',
+                     parent=self.odml_doc, reference='reference 1', repository='also unknown',
+                     link='???', include=False)
 
         odml.Property(name='first property', value=[1, 2, 3], parent=self.odml_doc.sections[0],
                       unit='Volt', uncertainty=3, reference='still unknown',


### PR DESCRIPTION
This assumes the odml to be saved as a metadata section with name 'odML document' in the NIX file as it is generated by the odML-to-nix converter.

The conversion is now depending on the input file format, so (.odML,. xml) is automatically converted to the corresponding .nix file and vice versa.