### PR TITLE
Fixes, docs and cli script

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,3 +65,32 @@ odML format, the following modifications occur when converting from odML to NIX:
 - Values of type `URL`, `person`, and `text` are treated as strings
 - Values of type `datetime`, `date`, and `time` are converted to string representations
 - Values of type `binary` are discarded
+
+
+# NIX (Neuroscience information exchange) format
+
+The NIX data model allows to store fully annotated scientific datasets, i.e. the 
+data together with its metadata within the same container. Our aim is to achieve 
+standardization by providing a common/generic data structure for a multitude of 
+data types.
+
+The source code of the core python library is freely available on 
+[GitHub](https://github.com/G-Node/nixpy) and can be installed via the 
+Python package manager `pip` by typing `pip install nixio`.
+
+More information about the project including related projects as well as tutorials and
+examples can be found at our odML [project page](https://g-node.github.io/nix/).
+
+
+# odML (Open metaData Markup Language) format
+
+The open metadata Markup Language is a file based format (XML, JSON, YAML) for storing
+metadata in an organised human- and machine-readable way. odML is an initiative to define
+and establish an open, flexible, and easy-to-use format to transport metadata.
+
+The source code of the core library is freely available on 
+[GitHub](https://github.com/G-Node/python-odml) and can be installed via the 
+Python package manager `pip` by typing `pip install odml`.
+
+More information about the project including related projects as well as tutorials and
+examples can be found at our odML [project page](https://g-node.github.io/python-odml/).

--- a/README.md
+++ b/README.md
@@ -1,13 +1,67 @@
 # odML ↔️ NIX metadata conversion tool
 
-This tool reads in odML / NIX files and writes the metadata structure to newly created NIX / odML files.
-When run as a script from the command line, it prints information regarding the number of Sections and Properties that were read, written, or skipped for various reasons.
+This tool reads in [odML](https://g-node.github.io/python-odml/) / 
+[NIX](https://g-node.github.io/nix/) files and writes the metadata structure to newly 
+created NIX / odML files. When run as a script from the command line, it prints 
+information regarding the number of Sections and Properties that were read, written, 
+or skipped for various reasons.
 
-For compatibility with the NIX metadata format, which differs slightly from the odML format, the following modifications occur when converting from odML to NIX:
+For more information on the odML and NIX data formats, please check the sections below.
+
+
+## Dependencies
+
+* Python 2.7 or 3.5+
+* Python packages:
+    * odml
+    * nixio (>=1.5.0b1)
+
+These dependency packages can be manually installed via the python package manager `pip`:
+
+`pip install odml nixio==1.5.0b3` 
+
+or by manually installing the nix-odML-converter from the repository root:
+
+`python setup.py install`
+
+
+## Building from source
+
+    git clone https://github.com/G-Node/nix-odML-converter.git
+    cd nix-odML-converter
+    python setup.py install
+
+## Usage
+
+After installing the package, you can use the `convert.py` script found in the
+directory 'nix-odML-converter/nixodmlconverter' that acts as a command line tool.
+
+You can use it to a) import the content of an existing odML file into a NIX file or
+b) to export the odML content of a NIX file into a new odML file. 
+
+### Import of odML into a NIX file
+
+From the command line use the `convert.py` script to import the contents of an existing
+odML file into a NIX file:
+
+    python nix-odML-convert/nixodmlconverter/convert.py odmlfile.xml nixfile.nix  
+
+The odML file has to be provided in XML format. 
+
+### Export odML from a NIX file
+
+From the command line use the `convert.py` script to export the contents of an existing 
+NIX file to a new odML file:
+
+    python nix-odML-convert/nixodmlconverter/convert.py nixfile.nix newodmlfile.xml
+
+### Usage notes
+
+For compatibility with the NIX metadata format, which differs slightly from the 
+odML format, the following modifications occur when converting from odML to NIX:
+
 - If a Section has a `reference` create a property called `reference`
-- If a Property has a `reference` put the reference in the Property's
-    values
+- If a Property has a `reference` put the reference in the Property's values
 - Values of type `URL`, `person`, and `text` are treated as strings
-- Values of type `datetime`, `date`, and `time` are converted to string
-    representations
+- Values of type `datetime`, `date`, and `time` are converted to string representations
 - Values of type `binary` are discarded

--- a/info.json
+++ b/info.json
@@ -9,7 +9,7 @@
     "Programming Language :: Python :: 2",
     "Programming Language :: Python :: 3",
     "License :: OSI Approved :: BSD License",
-    "Development Status :: 3 - Alpha",
+    "Development Status :: 4 - Beta",
     "Topic :: Scientific/Engineering",
     "Intended Audience :: Science/Research"
   ]

--- a/info.json
+++ b/info.json
@@ -1,5 +1,5 @@
 {
-  "VERSION": "0.0.2",
+  "VERSION": "0.0.3",
   "FORMAT_VERSION": "1.1",
   "AUTHOR": "Achilleas Koutsou, Julia Sprenger",
   "COPYRIGHT": "(c) 2018, German Neuroinformatics Node",

--- a/info.json
+++ b/info.json
@@ -1,5 +1,5 @@
 {
-  "VERSION": "0.0.3",
+  "VERSION": "0.0.4",
   "FORMAT_VERSION": "1.1",
   "AUTHOR": "Achilleas Koutsou, Julia Sprenger",
   "COPYRIGHT": "(c) 2018, German Neuroinformatics Node",

--- a/nixodmlconverter/convert.py
+++ b/nixodmlconverter/convert.py
@@ -248,8 +248,8 @@ def convert(filename, mode='append'):
             odml_doc = odml.load(filename)
         except InvalidVersionException:
             yesno = input("odML file format version is outdated. Automatically convert "
-                          "{} to the latest version (y/n)? ".format(outfilename,
-                                                                    mode.title()))
+                          "{} to the latest version (y/n)? ".format(outfilename))
+
             if yesno.lower() not in ("y", "yes"):
                 print("  Use the odml.tools.VersionConverter to convert "
                       "to the latest odML file version.")

--- a/nixodmlconverter/convert.py
+++ b/nixodmlconverter/convert.py
@@ -67,20 +67,20 @@ def print_info():
           "{type errors}\t Type Errors were encountered\n".format(**INFO))
 
 
-def convert_datetime(dt):
-    return dt.isoformat()
-
-
 def convert_value(val, dtype):
     global INFO
+
     if dtype == "binary":
         INFO["skipped binary values"] += 1
         return None
+
     if val is None:
         INFO["skipped none values"] += 1
         return None
+
     if dtype in ("date", "time", "datetime"):
-        val = convert_datetime(val)
+        val = val.isoformat()
+
     return val
 
 
@@ -137,7 +137,7 @@ def write_odml_doc(odmldoc, nixfile):
     if odmldoc.author:
         nixsec.create_property('odML author', [odmldoc.author])
     if odmldoc.date:
-        nixsec.create_property('odML date', [convert_datetime(odmldoc.date)])
+        nixsec.create_property('odML date', [odmldoc.date.isoformat()])
     if odmldoc.version:
         nixsec.create_property('odML version', [odmldoc.version])
     if odmldoc.repository:

--- a/nixodmlconverter/convert.py
+++ b/nixodmlconverter/convert.py
@@ -1,6 +1,6 @@
-"""nixodmlconvert
+"""nixodmlconverter
 
-nixodmlConversion converts odML content between odML and NIX files. The converter
+nixodmlconverter converts odML content between odML and NIX files. The converter
 a) imports content from an existing XML formatted odML file and appends it to
 a new or existing NIX file. The content of an existing odML file is automatically
 converted to the latest odML format before it is imported to the NIX file.
@@ -8,26 +8,32 @@ Furthermore, the converter b) exports odML content from a NIX file and saves it
 to an XML formatted odML file. If an odML file of the same name exists, the
 file will be overwritten.
 
-Usage: nixodmlconvert [-h] FILE [FILE ...]
+Usage: nixodmlconverter [-h] FILE...
 
 Arguments:
-    FILE            NIX or odML file. If the provided file is a NIX file,
-                    the odML content of this NIX file will be exported to an odML file
-                    of the same name. Existing odML output files will be overwritten.
+    FILE            NIX or odML file.
+
+                    If the provided file is a NIX file, the odML content of this NIX file
+                    will be exported to an odML file of the same name.
+                    Existing odML output files will be overwritten.
+
                     If the provided file is an XML formatted odML file, the content
                     of this odML file will be imported to a NIX file of the same name.
+
                     If a NIX file with the same name exists, the content of the odML
                     file will be appended, otherwise, a new NIX file will be created.
 
+                    Multiple files can be provided.
+
 Options:
-    [FILE ...]      Additional files for odML import or export.
     -h --help       Show this screen.
+    --version       Show version
 """
 
 import os
 import sys
 
-import argparse
+from docopt import docopt
 
 import nixio as nix
 import odml
@@ -271,14 +277,11 @@ def convert(filename, mode='append'):
 
 
 def main(args=None):
-    desc = "Converts an odML to a NIX file or extracts odML from a NIX file, " \
-           "also upgrades odML to the newest version."
-    parser = argparse.ArgumentParser(description=desc)
-    parser.add_argument('files', metavar='FILE', type=str,
-                        nargs='+', help='NIX or odML file')
-    args = parser.parse_args()
-    print(args.files)
-    for curr_file in args.files:
+    parser = docopt(__doc__, argv=args, version="0.0.3")
+
+    files = parser['FILE']
+    print(files)
+    for curr_file in files:
         convert(curr_file)
     print_info()
 

--- a/nixodmlconverter/convert.py
+++ b/nixodmlconverter/convert.py
@@ -49,7 +49,8 @@ INFO = {"sections read": 0,
         "skipped empty properties": 0,
         "skipped binary values": 0,
         "skipped none values": 0,
-        "type errors": 0}
+        "type errors": 0,
+        "mod_prop_values": 0}
 
 
 def print_info():
@@ -64,7 +65,9 @@ def print_info():
           "were of type 'binary'\n"
           "{skipped none values}\t Values were skipped because they were "
           "empty (None)\n"
-          "{type errors}\t Type Errors were encountered\n".format(**INFO))
+          "{type errors}\t Type Errors were encountered\n"
+          "{mod_prop_values}\t Values were modified due "
+          "to unsupported unicode characters\n".format(**INFO))
 
 
 def user_input(prompt):
@@ -144,9 +147,10 @@ def odml_to_nix_recurse(odmlseclist, nixparentsec):
                     enc_vals.append(val.encode('utf-8').decode('ascii', 'ignore'))
 
                 print("[WARNING] The Property.values currently do not support unicode. "
-                      "Values will be adjusted: {}/{}".format(nixvalues, enc_vals))
+                      "Values will be adjusted: \n{}\n{}".format(nixvalues, enc_vals))
 
                 nixprop.values = enc_vals
+                INFO["mod_prop_values"] += 1
 
             nixprop.definition = definition
             nixprop.unit = odmlprop.unit

--- a/nixodmlconverter/convert.py
+++ b/nixodmlconverter/convert.py
@@ -268,7 +268,7 @@ def convert(filename, mode='append'):
     print("Done")
 
 
-if __name__ == "__main__":
+def main(args=None):
     parser = argparse.ArgumentParser(description='Converts odML to NIX file or extracts odML from NIX file,'
                                                  ' also upgrades odML to newest version.')
     parser.add_argument('files', metavar='FILE', type=str, nargs='+', help='NIX or odML file')
@@ -277,3 +277,7 @@ if __name__ == "__main__":
     for f in args.files:
         convert(f)
     print_info()
+
+
+if __name__ == "__main__":
+    main(sys.argv[1:])

--- a/nixodmlconverter/convert.py
+++ b/nixodmlconverter/convert.py
@@ -137,7 +137,10 @@ def odml_to_nix_recurse(odmlseclist, nixparentsec):
                 INFO["skipped empty properties"] += 1
                 continue
 
-            nixprop = nixsec.create_property(propname, odmlprop.dtype, oid=odmlprop.id)
+            # We need to get the appropriate NIX DataType for the current odML values.
+            dtype = nix.DataType.get_dtype(nixvalues[0])
+
+            nixprop = nixsec.create_property(propname, dtype, oid=odmlprop.id)
             try:
                 nixprop.values = nixvalues
             except UnicodeError:

--- a/nixodmlconverter/convert.py
+++ b/nixodmlconverter/convert.py
@@ -1,3 +1,34 @@
+"""nixodmlConversion
+
+nixodmlConversion converts odML content between odML and NIX files. The converter
+can a) import content from an existing XML formatted odML file and append it to
+an existing NIX file. The content of an existing odML file is automatically converted
+to the latest odML format before it is imported to the NIX file.
+It further can b) export odML content from a NIX file and save it to an XML formatted
+odML file.
+If no output files are provided, the output files will be created using the filename
+of the input file. If an existing odML output file is provided, this odML file will
+be overwritten.
+
+Usage: nixodmlConversion [-h] FILE [FILE ...]
+
+Arguments:
+    FILE            NIX or odML file. If the first provided file is a NIX file,
+                    the odML content of this NIX file will be exported to an odML file.
+                    If the first provided file is an XML formatted odML file, the content
+                    of this odML file will be imported to a NIX file.
+
+Options:
+    [FILE ...]      Output file. Depending whether the first provided file is a NIX
+                    or an odML file, any provided output file should be of the opposite
+                    format. If an existing NIX file is provided as output file, the
+                    contents of the provided odML file will be appended to the existing
+                    NIX file.
+                    If an existing odML file is provided as output file, the output file
+                    will be overwritten.
+    -h --help       Show this screen.
+"""
+
 import os
 import sys
 

--- a/nixodmlconverter/convert.py
+++ b/nixodmlconverter/convert.py
@@ -327,7 +327,7 @@ def convert(filename, mode='append'):
 
 
 def main(args=None):
-    parser = docopt(__doc__, argv=args, version="0.0.3")
+    parser = docopt(__doc__, argv=args, version="0.0.4")
 
     files = parser['FILE']
     print(files)

--- a/nixodmlconverter/convert.py
+++ b/nixodmlconverter/convert.py
@@ -50,7 +50,8 @@ INFO = {"sections read": 0,
         "skipped binary values": 0,
         "skipped none values": 0,
         "type errors": 0,
-        "mod_prop_values": 0}
+        "mod_prop_values": 0,
+        "odml_types_omitted": 0}
 
 
 def print_info():
@@ -67,7 +68,9 @@ def print_info():
           "empty (None)\n"
           "{type errors}\t Type Errors were encountered\n"
           "{mod_prop_values}\t Values were modified due "
-          "to unsupported unicode characters\n".format(**INFO))
+          "to unsupported unicode characters\n"
+          "{odml_types_omitted}\t Unidentified odml value types omitted "
+          "(using string instead)\n".format(**INFO))
 
 
 def user_input(prompt):
@@ -162,6 +165,15 @@ def odml_to_nix_recurse(odmlseclist, nixparentsec):
             nixprop.value_origin = odmlprop.value_origin
             nixprop.dependency = odmlprop.dependency
             nixprop.dependency_value = odmlprop.dependency_value
+
+            # We also need to provide the appropriate odML data type for a potential
+            # later export from NIX to odML.
+            try:
+                nixprop.odml_type = nix.property.OdmlType(odmlprop.dtype)
+            except ValueError:
+                print("[WARNING] Cannot set odml type {}".format(odmlprop.dtype))
+                INFO["odml_types_omitted"] += 1
+
             INFO["properties written"] += 1
 
         odml_to_nix_recurse(odmlsec.sections, nixsec)

--- a/nixodmlconverter/convert.py
+++ b/nixodmlconverter/convert.py
@@ -1,31 +1,26 @@
-"""nixodmlConversion
+"""nixodmlconvert
 
 nixodmlConversion converts odML content between odML and NIX files. The converter
-can a) import content from an existing XML formatted odML file and append it to
-an existing NIX file. The content of an existing odML file is automatically converted
-to the latest odML format before it is imported to the NIX file.
-It further can b) export odML content from a NIX file and save it to an XML formatted
-odML file.
-If no output files are provided, the output files will be created using the filename
-of the input file. If an existing odML output file is provided, this odML file will
-be overwritten.
+a) imports content from an existing XML formatted odML file and appends it to
+a new or existing NIX file. The content of an existing odML file is automatically
+converted to the latest odML format before it is imported to the NIX file.
+Furthermore, the converter b) exports odML content from a NIX file and saves it
+to an XML formatted odML file. If an odML file of the same name exists, the
+file will be overwritten.
 
-Usage: nixodmlConversion [-h] FILE [FILE ...]
+Usage: nixodmlconvert [-h] FILE [FILE ...]
 
 Arguments:
-    FILE            NIX or odML file. If the first provided file is a NIX file,
-                    the odML content of this NIX file will be exported to an odML file.
-                    If the first provided file is an XML formatted odML file, the content
-                    of this odML file will be imported to a NIX file.
+    FILE            NIX or odML file. If the provided file is a NIX file,
+                    the odML content of this NIX file will be exported to an odML file
+                    of the same name. Existing odML output files will be overwritten.
+                    If the provided file is an XML formatted odML file, the content
+                    of this odML file will be imported to a NIX file of the same name.
+                    If a NIX file with the same name exists, the content of the odML
+                    file will be appended, otherwise, a new NIX file will be created.
 
 Options:
-    [FILE ...]      Output file. Depending whether the first provided file is a NIX
-                    or an odML file, any provided output file should be of the opposite
-                    format. If an existing NIX file is provided as output file, the
-                    contents of the provided odML file will be appended to the existing
-                    NIX file.
-                    If an existing odML file is provided as output file, the output file
-                    will be overwritten.
+    [FILE ...]      Additional files for odML import or export.
     -h --help       Show this screen.
 """
 

--- a/nixodmlconverter/convert.py
+++ b/nixodmlconverter/convert.py
@@ -67,6 +67,20 @@ def print_info():
           "{type errors}\t Type Errors were encountered\n".format(**INFO))
 
 
+def user_input(prompt):
+    """
+    Executes the appropriate user input function dependent on
+    the Python version.
+
+    :param prompt: Information string prompting user input.
+    :return: User input string.
+    """
+    if sys.version_info < (3, 0):
+        return raw_input(prompt)
+
+    return input(prompt)
+
+
 def convert_value(val, dtype):
     global INFO
 
@@ -241,8 +255,8 @@ def convert(filename, mode='append'):
     # Check output file
     outfilename = file_base + output_format
     if os.path.exists(outfilename):
-        yesno = input("File {} already exists. "
-                      "{} (y/n)? ".format(outfilename, mode.title()))
+        yesno = user_input("File {} already exists. "
+                           "{} (y/n)? ".format(outfilename, mode.title()))
         if yesno.lower() not in ("y", "yes"):
             print("Aborted")
             return
@@ -253,8 +267,10 @@ def convert(filename, mode='append'):
         try:
             odml_doc = odml.load(filename)
         except InvalidVersionException:
-            yesno = input("odML file format version is outdated. Automatically convert "
-                          "{} to the latest version (y/n)? ".format(outfilename))
+
+            yesno = user_input("odML file format version is outdated. "
+                               "Automatically convert {} to the latest version "
+                               "(y/n)? ".format(outfilename))
 
             if yesno.lower() not in ("y", "yes"):
                 print("  Use the odml.tools.VersionConverter to convert "

--- a/setup.py
+++ b/setup.py
@@ -42,5 +42,6 @@ setup(
     long_description=description_text,
     long_description_content_type="text/markdown",
     classifiers=CLASSIFIERS,
-    license="BSD"
+    license="BSD",
+    entry_points={'console_scripts': ['nixodmlconverter=nixodmlconverter.convert:main']}
 )

--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,7 @@ packages = ['nixodmlconverter']
 with open('README.md', encoding="utf8") as f:
     description_text = f.read()
 
-install_req = ["odML", "nixio>=1.5.0b1"]
+install_req = ["odML", "nixio>=1.5.0b1", "docopt"]
 
 if sys.version_info < (3, 4):
     install_req += ["enum34"]
@@ -43,5 +43,5 @@ setup(
     long_description_content_type="text/markdown",
     classifiers=CLASSIFIERS,
     license="BSD",
-    entry_points={'console_scripts': ['nixodmlconverter=nixodmlconverter.convert:main']}
+    entry_points={"console_scripts": ["nixodmlconverter=nixodmlconverter.convert:main"]}
 )


### PR DESCRIPTION
This PR adds a couple of bugfixes, makes the converter usable as a command line script and adds documentation updates:
- Updates the setup script to install the converter as a command line script called `nixodmlconverter`.
- Fixes that `input` is not available in Python2
- Hotfixes that odML `Property.values` cannot be imported into NIX if they contain non-ascii characters. The hotfix will probably remain until this issue is fixed in NIX - see [issue](https://github.com/G-Node/nixpy/issues/383)
- Major updates to README and docstring
