### PR TITLE
Updates and fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,28 +13,11 @@ or skipped for various reasons.
 
 For more information on the odML and NIX data formats, please check the sections below.
 
+## Installation
 
-## Dependencies
+You can easily install the converter via the Python package manager `pip`.
 
-* Python 2.7 or 3.5+
-* Python packages:
-    * odml
-    * nixio (>=1.5.0b1)
-
-These dependency packages can be manually installed via the python package manager `pip`:
-
-`pip install odml nixio==1.5.0b3` 
-
-or by manually installing the nix-odML-converter from the repository root:
-
-`python setup.py install`
-
-
-## Building from source
-
-    git clone https://github.com/G-Node/nix-odML-converter.git
-    cd nix-odML-converter
-    python setup.py install
+    pip install nixodmlconverter
 
 ## Usage
 
@@ -70,6 +53,31 @@ odML format, the following modifications occur when converting from odML to NIX:
 - Values of type `URL`, `person`, and `text` are treated as strings
 - Values of type `datetime`, `date`, and `time` are converted to string representations
 - Values of type `binary` are discarded
+
+
+## Building from source
+
+You can also install the package by cloning the github repository and
+installing from source.
+
+    git clone https://github.com/G-Node/nix-odML-converter.git
+    cd nix-odML-converter
+    python setup.py install
+
+## Dependencies
+
+* Python 2.7 or 3.5+
+* Python packages:
+    * odml
+    * nixio (>=1.5.0b1)
+
+These dependency packages can be manually installed via the python package manager `pip`:
+
+`pip install odml nixio==1.5.0b3` 
+
+or by manually installing the nix-odML-converter from the repository root:
+
+`python setup.py install`
 
 
 # NIX (Neuroscience information exchange) format

--- a/README.md
+++ b/README.md
@@ -1,3 +1,8 @@
+![Travis build](https://travis-ci.org/G-Node/nix-odML-converter.svg?branch=master)
+[![Build status](https://ci.appveyor.com/api/projects/status/fc30meltvawsbpgt?svg=true)](https://ci.appveyor.com/project/G-Node/nix-odml-converter)
+[![PyPI version](https://img.shields.io/pypi/v/nixodmlconverter.svg)](https://pypi.org/project/nixodmlconverter/)
+
+
 # odML ↔️ NIX metadata conversion tool
 
 This tool reads in [odML](https://g-node.github.io/python-odml/) / 

--- a/info.json
+++ b/info.json
@@ -1,16 +1,18 @@
 {
-  "VERSION": "0.0.4",
+  "VERSION": "0.0.5",
   "FORMAT_VERSION": "1.1",
   "AUTHOR": "Achilleas Koutsou, Julia Sprenger",
   "COPYRIGHT": "(c) 2018, German Neuroinformatics Node",
   "CONTACT": "dev@g-node.org",
   "HOMEPAGE": "https://github.com/G-Node/nix-odml-converter",
   "CLASSIFIERS": [
-    "Programming Language :: Python :: 2",
-    "Programming Language :: Python :: 3",
-    "License :: OSI Approved :: BSD License",
     "Development Status :: 4 - Beta",
+    "Programming Language :: Python",
+    "Programming Language :: Python :: 2.7",
+    "Programming Language :: Python :: 3.5",
+    "Programming Language :: Python :: 3.6",
     "Topic :: Scientific/Engineering",
     "Intended Audience :: Science/Research"
+    "License :: OSI Approved :: BSD License",
   ]
 }

--- a/info.json
+++ b/info.json
@@ -12,7 +12,7 @@
     "Programming Language :: Python :: 3.5",
     "Programming Language :: Python :: 3.6",
     "Topic :: Scientific/Engineering",
-    "Intended Audience :: Science/Research"
-    "License :: OSI Approved :: BSD License",
+    "Intended Audience :: Science/Research",
+    "License :: OSI Approved :: BSD License"
   ]
 }

--- a/nixodmlconverter/convert.py
+++ b/nixodmlconverter/convert.py
@@ -89,8 +89,6 @@ def user_input(prompt):
 
 
 def convert_value(val, dtype):
-    global INFO
-
     if dtype == "binary":
         INFO["skipped binary values"] += 1
         return None
@@ -177,7 +175,6 @@ def odml_to_nix_property(odmlprop, nixsec):
 
 
 def odml_to_nix_recurse(odmlseclist, nixparentsec):
-    global INFO
     for odmlsec in odmlseclist:
         INFO["sections read"] += 1
         secname = odmlsec.name

--- a/nixodmlconverter/convert.py
+++ b/nixodmlconverter/convert.py
@@ -120,7 +120,7 @@ def odml_to_nix_property(odmlprop, nixsec):
     """
     INFO["properties read"] += 1
     nixvalues = []
-    for val in odmlprop.value:
+    for val in odmlprop.values:
         nixv = convert_value(val, odmlprop.dtype)
         if nixv is not None:
             nixvalues.append(nixv)

--- a/nixodmlconverter/convert.py
+++ b/nixodmlconverter/convert.py
@@ -56,7 +56,7 @@ INFO = {"sections read": 0,
 
 
 def print_info():
-    print("Conversion info")
+    print("\nConversion info")
     print("{sections read}\t Sections were read\n"
           "{sections written}\t Sections were written\n"
           "{properties read}\t Properties were read\n"
@@ -86,6 +86,18 @@ def user_input(prompt):
         return raw_input(prompt)
 
     return input(prompt)
+
+#def print_same_line(msg):
+#    """
+#    Print a message to the same line on the command line and
+#    use the appropriate function depending on the Python version.
+#
+#    :param msg: Text to be displayed on the command line
+#    """
+#    if sys.version_info < (3, 0):
+#        print("{}\r".format(msg)),
+#    else:
+#        print(msg, end="\r")
 
 
 def convert_value(val, dtype):
@@ -140,8 +152,8 @@ def odml_to_nix_property(odmlprop, nixsec):
         for val in nixvalues:
             enc_vals.append(val.encode('utf-8').decode('ascii', 'ignore'))
 
-        print("[WARNING] The Property.values currently do not support unicode. "
-              "Values will be adjusted: \n{}\n{}".format(nixvalues, enc_vals))
+        print("\n[WARNING] The Property.values currently do not support unicode. "
+              "Values will be adjusted: \n{}\n{}\n".format(nixvalues, enc_vals))
 
         nixprop.values = enc_vals
         INFO["mod_prop_values"] += 1
@@ -152,8 +164,8 @@ def odml_to_nix_property(odmlprop, nixsec):
         nixprop.unit = odmlprop.unit
     except UnicodeDecodeError:
         if u"Ω" in odmlprop.unit:
-            print("[WARNING] Property.unit currently does not support the omega "
-                  "unicode character. It will be replaced by 'Ohm'.")
+            print("\n[WARNING] Property.unit currently does not support the omega "
+                  "unicode character. It will be replaced by 'Ohm'.\n")
             nixprop.unit = odmlprop.unit.replace(u"Ω", "Ohm").encode('ascii')
 
     nixprop.definition = odmlprop.definition
@@ -168,7 +180,7 @@ def odml_to_nix_property(odmlprop, nixsec):
     try:
         nixprop.odml_type = nix.property.OdmlType(odmlprop.dtype)
     except ValueError:
-        print("[WARNING] Cannot set odml type {}".format(odmlprop.dtype))
+        print("\n[WARNING] Cannot set odml type {}\n".format(odmlprop.dtype))
         INFO["odml_types_omitted"] += 1
 
     INFO["properties written"] += 1
@@ -194,6 +206,9 @@ def odml_to_nix_recurse(odmlseclist, nixparentsec):
 
         for odmlprop in odmlsec.properties:
             odml_to_nix_property(odmlprop, nixsec)
+            msg = ("\rProcessed Sections: {}; processed Properties: {}".format(
+                INFO['sections read'], INFO['properties read']))
+            sys.stdout.write(msg)
 
         odml_to_nix_recurse(odmlsec.sections, nixsec)
 
@@ -372,7 +387,7 @@ def convert(filename, mode='append'):
     else:
         raise ValueError('Unknown file format {}'.format(output_format))
 
-    print("Done")
+    print("\nDone")
 
 
 def main(args=None):


### PR DESCRIPTION
This PR
- in a odml->nix conversion sanitizes the 'omega' symbol to 'Ohm' if it is used in a property.unit. Otherwise nixpy breaks when using Python 2.
- removes the usage of a deprecated odml attribute and refactors the command line output for the user.
- enables the export of any metadata section from NIX. Closes #17.
- updates the installation notice in the README
- adds vanity badges to the README