### PR TITLE
Dependency fix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,11 @@ dist: trusty
 language: python
 
 matrix:
+  allow_failures:
+    - os: linux
+      python: "3.9-dev"
+      dist: bionic
+
   include:
     - os: linux
       python: "2.7"
@@ -11,7 +16,20 @@ matrix:
       python: "3.5"
     - os: linux
       python: "3.6"
+    - os: linux
+      python: "3.7"
+      dist: xenial
+    - os: linux
+      python: "3.8"
+      dist: xenial
+    - os: linux
+      python: "3.9-dev"
+      dist: bionic
 
+    - os: osx
+      language: generic
+      env:
+        - OSXENV=2.7.14
     - os: osx
       language: generic
       env:
@@ -19,7 +37,11 @@ matrix:
     - os: osx
       language: generic
       env:
-        - OSXENV=2.7.14
+        - OSXENV=3.7.0
+    - os: osx
+      language: generic
+      env:
+        - OSXENV=3.8.0
 
 install:
   - export PYVER=${TRAVIS_PYTHON_VERSION:0:1}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,14 +1,13 @@
 # Changelog
 
-Used to document all changes from previous releases and collect changes 
-until the next release.
+Used to document all changes from previous releases and collect changes until the next release.
 
-# Latest changes in master
+# Version 0.0.7
+- Update imports from odml where the package structure has changed with version 1.4.4.
 
-- Moved `info.json` to the `nixodmlconverter` folder to enable import of the
-package version number.
-- Removed `FORMAT_VERSION` from `info.json` since that is odML file format
-specific and should be defined in the odML python package only.
+# Version 0.0.6
+- Moved `info.json` to the `nixodmlconverter` folder to enable import of the package version number.
+- Removed `FORMAT_VERSION` from `info.json` since that is odML file format specific and should be defined in the odML python package only.
 
 # Version 0.0.5
 
@@ -22,4 +21,3 @@ specific and should be defined in the odML python package only.
 - odML `Property.values` can now be imported into NIX if they contain non-ascii characters.
 - in a odml->nix conversion the 'omega' symbol is sanitized to 'Ohm' if it is used in a `Property.unit`. Otherwise nixpy breaks when using Python 2.
 - removes the usage of the deprecated odml attribute `Property.value` and refactors the command line output for the user.
-

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-![Travis build](https://travis-ci.org/G-Node/nix-odML-converter.svg?branch=master)
+[![Travis build](https://travis-ci.org/G-Node/nix-odML-converter.svg?branch=master)](https://travis-ci.org/G-Node/nix-odML-converter/)
 [![Build status](https://ci.appveyor.com/api/projects/status/fc30meltvawsbpgt?svg=true)](https://ci.appveyor.com/project/G-Node/nix-odml-converter)
 [![PyPI version](https://img.shields.io/pypi/v/nixodmlconverter.svg)](https://pypi.org/project/nixodmlconverter/)
 

--- a/README.md
+++ b/README.md
@@ -66,18 +66,20 @@ installing from source.
 
 ## Dependencies
 
-* Python 2.7 or 3.5+
+* Python 3.6+
 * Python packages:
-    * odml
-    * nixio (>=1.5.0b1)
+    * odml (>=1.4.5)
+    * nixio (>=1.5.0b3)
 
 These dependency packages can be manually installed via the python package manager `pip`:
 
-`pip install odml nixio==1.5.0b3` 
+`pip install "odml>=1.4.5" "nixio>=1.5.0b3"` 
 
 or by manually installing the nix-odML-converter from the repository root:
 
 `python setup.py install`
+
+Python 2 has reached end of life. We will not keep any future versions of nixodmlconverter Python 2 compatible and also recommend using a Python version >= 3.6.
 
 
 # NIX (Neuroscience information exchange) format

--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ or by manually installing the nix-odML-converter from the repository root:
 
 `python setup.py install`
 
-Python 2 has reached end of life. We will not keep any future versions of nixodmlconverter Python 2 compatible and also recommend using a Python version >= 3.6.
+Python 2 has reached end of life. Future versions of nixodmlconverter will no longer support Python 2.  We further recommend using a Python version >= 3.6.
 
 
 # NIX (Neuroscience information exchange) format

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,17 +1,38 @@
+version: 1.4.{build}
+
+image: Visual Studio 2017
+
 environment:
   matrix:
     - PYTHON: "C:\\Python27"
-      PYVER: "2.7"
-    - PYTHON: "C:\\Python35"
-      PYVER: "3.5"
+      PYVER: 2
+      BITS: 32
     - PYTHON: "C:\\Python36"
-      PYVER: "3.6"
+      PYVER: 3
+      BITS: 32
+    - PYTHON: "C:\\Python37"
+      PYVER: 3
+      BITS: 32
+    - PYTHON: "C:\\Python38"
+      PYVER: 3
+      BITS: 32
     - PYTHON: "C:\\Python27-x64"
-      PYVER: "2.7"
-    - PYTHON: "C:\\Python35-x64"
-      PYVER: "3.5"
+      PYVER: 2
+      BITS: 64
     - PYTHON: "C:\\Python36-x64"
-      PYVER: "3.6"
+      PYVER: 3
+      BITS: 64
+    - PYTHON: "C:\\Python37-x64"
+      PYVER: 3
+      BITS: 64
+    - PYTHON: "C:\\Python38-x64"
+      PYVER: 3
+      BITS: 64
+
+init:
+  - "ECHO %PYTHON% %vcvars% (%bits%)"
+  - ps: $env:PATH = "$env:PYTHON;$env:PATH;"
+  - python -c "import sys;print('Python version is {}'.format(sys.version))"
 
 build: false
 

--- a/nixodmlconverter/__init__.py
+++ b/nixodmlconverter/__init__.py
@@ -6,7 +6,7 @@ from .info import VERSION
 
 if _python_version.major < 3 or _python_version.major == 3 and _python_version.minor < 6:
     msg = "The '%s' package is not tested with your Python version. " % __name__
-    msg += "Please consider upgrading to the latest Python distribution."
+    msg += "Please consider upgrading to a Python version >= 3.6."
     warnings.warn(msg)
 
 __version__ = VERSION

--- a/nixodmlconverter/__init__.py
+++ b/nixodmlconverter/__init__.py
@@ -1,0 +1,12 @@
+import warnings
+
+from sys import version_info as _python_version
+
+from .info import VERSION
+
+if _python_version.major < 3 or _python_version.major == 3 and _python_version.minor < 6:
+    msg = "The '%s' package is not tested with your Python version. " % __name__
+    msg += "Please consider upgrading to the latest Python distribution."
+    warnings.warn(msg)
+
+__version__ = VERSION

--- a/nixodmlconverter/convert.py
+++ b/nixodmlconverter/convert.py
@@ -39,8 +39,8 @@ from docopt import docopt
 import nixio as nix
 import odml
 
-from odml.tools.format_converter import VersionConverter
-from odml.tools.odmlparser import ODMLReader
+from odml.tools.converters import VersionConverter
+from odml.tools import ODMLReader
 from odml.tools.parser_utils import InvalidVersionException
 from nixodmlconverter.info import VERSION
 

--- a/nixodmlconverter/info.json
+++ b/nixodmlconverter/info.json
@@ -1,15 +1,15 @@
 {
-  "VERSION": "0.0.6",
+  "VERSION": "0.0.7",
   "AUTHOR": "Achilleas Koutsou, Julia Sprenger, Michael Sonntag",
-  "COPYRIGHT": "(c) 2018, German Neuroinformatics Node",
+  "COPYRIGHT": "(c) 2020, German Neuroinformatics Node",
   "CONTACT": "dev@g-node.org",
   "HOMEPAGE": "https://github.com/G-Node/nix-odml-converter",
   "CLASSIFIERS": [
     "Development Status :: 4 - Beta",
     "Programming Language :: Python",
-    "Programming Language :: Python :: 2.7",
-    "Programming Language :: Python :: 3.5",
     "Programming Language :: Python :: 3.6",
+    "Programming Language :: Python :: 3.7",
+    "Programming Language :: Python :: 3.8",
     "Topic :: Scientific/Engineering",
     "Intended Audience :: Science/Research",
     "License :: OSI Approved :: BSD License"

--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,9 @@ packages = ['nixodmlconverter']
 with open('README.md', encoding="utf8") as f:
     description_text = f.read()
 
-install_req = ["odml>=1.4.5", "nixio>=1.5.0b1", "docopt"]
+# Older Python installations might come with a "six" version<1.12.0
+# for which nixio will fail.
+install_req = ["odml>=1.4.5", "nixio>=1.5.0b1", "docopt", "six>=1.12.0"]
 
 if sys.version_info < (3, 4):
     install_req += ["enum34"]

--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,7 @@ packages = ['nixodmlconverter']
 with open('README.md', encoding="utf8") as f:
     description_text = f.read()
 
-install_req = ["odML", "nixio>=1.5.0b1", "docopt"]
+install_req = ["odml>=1.4.5", "nixio>=1.5.0b1", "docopt"]
 
 if sys.version_info < (3, 4):
     install_req += ["enum34"]


### PR DESCRIPTION
With v1.4.4 the structure of the [python-odml](https://github.com/G-Node/python-odml/releases/tag/v1.4.4) library was refactored to reduce import cycles. During this the 'format_converter.py' file had been moved from `odml.tools` to `odml.tools.converters` which in turn broke the corresponding import used in this package.

This PR
- fixes the `FormatConverter` import issue
- updates the `odml` version number dependency in `setup.py` accordingly
- adds minor updates to info.json, CHANGELOG, README
- adds a Python < 3.6 warning on package import
- updates the CI builds to also include Python 3.7 - 3.9
