### PR TITLE
Property Error Skip

### DIFF
--- a/nixodmlconverter/convert.py
+++ b/nixodmlconverter/convert.py
@@ -37,7 +37,6 @@ import re
 
 from docopt import docopt
 
-import numpy as np
 import nixio as nix
 import odml
 

--- a/nixodmlconverter/convert.py
+++ b/nixodmlconverter/convert.py
@@ -362,6 +362,12 @@ def nix_to_odml_property(nixprop, odml_sec):
 
     if 'id' in nix_prop_attributes:
         nix_prop_attributes['oid'] = nix_prop_attributes.pop('id')
+    non_byte_vals = []
+    for val in list(nix_prop_attributes.pop('values')):
+        if isinstance(val, bytes):
+            non_byte_vals += [str(val, "utf-8")]
+        else:
+            non_byte_vals += [val]
 
     odml_type = None
     if 'odml_type' in nix_prop_attributes:
@@ -369,10 +375,10 @@ def nix_to_odml_property(nixprop, odml_sec):
     if odml_type and odml_type.value:
         nix_prop_attributes['dtype'] = odml_type.value
     else:
-        nix_prop_attributes['dtype'] = infer_dtype(nix_prop_attributes['values'])
+        nix_prop_attributes['dtype'] = infer_dtype(non_byte_vals)
 
     nix_prop_attributes['parent'] = odml_sec
-    nix_prop_attributes['values'] = list(nix_prop_attributes.pop('values'))
+    nix_prop_attributes['values'] = non_byte_vals
 
     odml.Property(**nix_prop_attributes)
     INFO["properties written"] += 1

--- a/nixodmlconverter/convert.py
+++ b/nixodmlconverter/convert.py
@@ -141,6 +141,12 @@ def infer_dtype(values):
 
     return "string"
 
+def non_binary_value(val):
+    if isinstance(val, bytes):
+        return str(val, "utf-8")
+    else:
+        return val
+
 #def print_same_line(msg):
 #    """
 #    Print a message to the same line on the command line and
@@ -362,19 +368,16 @@ def nix_to_odml_property(nixprop, odml_sec):
                                for attr in prop_attributes if hasattr(nixprop, attr)}
 
         if 'id' in nix_prop_attributes:
-            nix_prop_attributes['oid'] = nix_prop_attributes.pop('id')
+            nix_prop_attributes['oid'] = non_binary_value(nix_prop_attributes.pop('id'))
         non_byte_vals = []
         for val in list(nix_prop_attributes.pop('values')):
-            if isinstance(val, bytes):
-                non_byte_vals += [str(val, "utf-8")]
-            else:
-                non_byte_vals += [val]
+            non_byte_vals += [non_binary_value(val)]
 
         odml_type = None
         if 'odml_type' in nix_prop_attributes:
-            odml_type = nix_prop_attributes.pop('odml_type')
+            odml_type = non_binary_value(nix_prop_attributes.pop('odml_type'))
         if odml_type and odml_type.value:
-            nix_prop_attributes['dtype'] = odml_type.value
+            nix_prop_attributes['dtype'] = non_binary_value(odml_type.value)
         else:
             nix_prop_attributes['dtype'] = infer_dtype(non_byte_vals)
 

--- a/nixodmlconverter/convert.py
+++ b/nixodmlconverter/convert.py
@@ -387,8 +387,8 @@ def nix_to_odml_property(nixprop, odml_sec):
 
         odml.Property(**nix_prop_attributes)
         INFO["properties written"] += 1
-    except Exception as e:
-        print("Could not convert property", nixprop, ":", e)
+    except TypeError as t_e:
+        print("Could not convert property " + str(nixprop) + ":" + str(t_e))
 
 
 def nix_to_odml_recurse(nix_section_list, odml_section):

--- a/nixodmlconverter/convert.py
+++ b/nixodmlconverter/convert.py
@@ -381,6 +381,7 @@ def nix_to_odml_property(nixprop, odml_sec):
         else:
             nix_prop_attributes['dtype'] = infer_dtype(non_byte_vals)
 
+        nix_prop_attributes['reference'] = non_binary_value(nix_prop_attributes.pop('reference'))
         nix_prop_attributes['parent'] = odml_sec
         nix_prop_attributes['values'] = non_byte_vals
 

--- a/test/test_convert.py
+++ b/test/test_convert.py
@@ -68,3 +68,4 @@ class TestBlock(unittest.TestCase):
                                  '../odmlfiles/test')
         nix_file = nix.File.open(file_path + '.nix', "r")
         convert.odmlwrite(nix_file, file_path + '.xml')
+        nix_file.close()

--- a/test/test_convert.py
+++ b/test/test_convert.py
@@ -62,3 +62,8 @@ class TestBlock(unittest.TestCase):
                     self.assertEqual(getattr(prop, attr), getattr(prop2, attr))
 
         nix_file.close()
+
+    def test_example_nix_file(self):
+        nf = '../odmlfiles/test.nix'
+        nix_file = nix.File.open(nf, "r")
+        convert.odmlwrite(nix_file, '../odmlfiles/test.xml')

--- a/test/test_convert.py
+++ b/test/test_convert.py
@@ -64,6 +64,7 @@ class TestBlock(unittest.TestCase):
         nix_file.close()
 
     def test_example_nix_file(self):
-        nf = '../odmlfiles/test.nix'
-        nix_file = nix.File.open(nf, "r")
-        convert.odmlwrite(nix_file, '../odmlfiles/test.xml')
+        file_path = os.path.join(os.path.dirname(os.path.realpath(__file__)), 
+                                 '../odmlfiles/test')
+        nix_file = nix.File.open(file_path + '.nix', "r")
+        convert.odmlwrite(nix_file, file_path + '.xml')


### PR DESCRIPTION
With this PR:

- Properties that cannot be converted from nix to odml will be skipped but print a warning message
- nix values stored as bytes are converted for use in odml-files